### PR TITLE
Add aspect_ratio option for base image generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ BFL_API_KEY=your_bfl_api_key_here
 REPLICATE_API_KEY=your_replicate_api_key_here
 # Change to REPLICATE to use Replicate as default provider
 DEFAULT_PROVIDER=BFL
+# Aspect ratio for generated images
+ASPECT_RATIO=1:1

--- a/core/config.py
+++ b/core/config.py
@@ -12,5 +12,8 @@ REPLICATE_EDIT_MODEL = "blackforest-ai/flux-kontext-pro"
 # ``DEFAULT_PROVIDER`` environment variable to ``"REPLICATE"`` or ``"BFL"``.
 DEFAULT_PROVIDER = os.environ.get("DEFAULT_PROVIDER", "BFL").upper()
 
+# Default aspect ratio used for image generation
+ASPECT_RATIO = os.environ.get("ASPECT_RATIO", "1:1")
+
 # Output format for generated images
 IMAGE_FORMAT = "png"

--- a/core/generate.py
+++ b/core/generate.py
@@ -36,7 +36,7 @@ def poll_image_bfl(request_id: str):
         elif status not in ["Processing", "Queued", "Pending"]: 
             raise ValueError(f"An error or unexpected status occurred: {request_json}")
 
-def generate_base_image_bfl(prompt: str) -> str:
+def generate_base_image_bfl(prompt: str, aspect_ratio: str = ASPECT_RATIO) -> str:
     request = requests.post(
         f"https://api.bfl.ai/v1/{BFL_BASE_MODEL}",
         headers={
@@ -46,7 +46,7 @@ def generate_base_image_bfl(prompt: str) -> str:
         },
         json={
             "prompt": prompt,
-            "aspect_ratio": "1:1"
+            "aspect_ratio": aspect_ratio
         }
     ).json()
 
@@ -75,12 +75,12 @@ def edit_base_image_bfl(image: Image.Image, instruct_prompt: str) -> str:
     return request_id
 
 
-def generate_base_image_replicate(prompt: str) -> Image.Image:
+def generate_base_image_replicate(prompt: str, aspect_ratio: str = ASPECT_RATIO) -> Image.Image:
     """Generate a base image using the Replicate API."""
     client = replicate.Client(api_token=os.environ.get("REPLICATE_API_KEY"))
     output = client.run(
         REPLICATE_BASE_MODEL,
-        input={"prompt": prompt, "aspect_ratio": "1:1"},
+        input={"prompt": prompt, "aspect_ratio": aspect_ratio},
     )
     if isinstance(output, list):
         output = output[0]

--- a/main.py
+++ b/main.py
@@ -82,10 +82,10 @@ def main():
             print(f"Creating character with ID: {job_id}")
             print("Generating base image...")
             if provider == "BFL":
-                base_image_id = generate_base_image_bfl(base_prompt)
+                base_image_id = generate_base_image_bfl(base_prompt, aspect_ratio=ASPECT_RATIO)
                 base_image = poll_image_bfl(base_image_id)
             else:
-                base_image = generate_base_image_replicate(base_prompt)
+                base_image = generate_base_image_replicate(base_prompt, aspect_ratio=ASPECT_RATIO)
             base_image.save(f"outputs/{job_id}/base.{IMAGE_FORMAT}")
             with open(f"outputs/{job_id}/base.txt", "w", encoding="utf-8") as f:
                 f.write(base_prompt)


### PR DESCRIPTION
## Summary
- allow setting aspect ratio via environment variable
- add ASPECT_RATIO option to config and .env.example
- pass aspect ratio to Black Forest Labs and Replicate generators

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68497a6e89508326b7a214acfab33bd7